### PR TITLE
test: ensure createIssue errors on null payload

### DIFF
--- a/tests/unit/services/linearService.test.ts
+++ b/tests/unit/services/linearService.test.ts
@@ -95,7 +95,7 @@ describe('LinearService', () => {
 
     it('should handle "me" assignee filter', async () => {
       // Arrange
-      const mockIssues = [];
+      const mockIssues: any[] = [];
       mockLinearClient.issues.mockResolvedValue({ nodes: mockIssues });
       
       // Act
@@ -175,6 +175,19 @@ describe('LinearService', () => {
         title: 'Test Issue',
         assigneeId: 'test-user',
       });
+    });
+
+    it('should throw error when API returns no issue', async () => {
+      // Arrange
+      mockLinearClient.createIssue.mockResolvedValue({ issue: null });
+
+      // Act
+      const service = LinearService.getInstance();
+
+      // Assert
+      await expect(
+        service.createIssue('team-1', 'Test Issue')
+      ).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary
- test LinearService.createIssue rejecting when API returns `{ issue: null }`
- type mock issues array for strict TypeScript

## Testing
- `npm test tests/unit/services/linearService.test.ts` *(fails: LinearClient.mockImplementation is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689741c9b5408325994be15437b01c7c